### PR TITLE
Propose the correct link to supple mat

### DIFF
--- a/_posts/2018-03-31-fan18b.md
+++ b/_posts/2018-03-31-fan18b.md
@@ -45,6 +45,6 @@ issued:
 pdf: http://proceedings.mlr.press/v84/fan18b/fan18b.pdf
 extras:
 - label: Supplementary PDF
-  link: http://proceedings.mlr.press/v84/fan18b/fan18b-supp.pdf
+  link: http://proceedings.mlr.press/v84/fan18a/fan18a-supp.pdf
 # Format based on citeproc: http://blog.martinfenner.org/2013/07/30/citeproc-yaml-for-bibliographies/
 ---


### PR DESCRIPTION
Dear Editors, 
The previous link for the supple material of the Binary Space Partitioning-Tree process is not correct. This is the correct link to the supplementary material of the Binary Space Partitioning-Tree Process. 
Thanks, 
Xuhui